### PR TITLE
Document March 2025 release window decision

### DIFF
--- a/release_window_plan.md
+++ b/release_window_plan.md
@@ -1,0 +1,18 @@
+# Release Window Decision
+
+## Selected Window
+- **Primary target:** March 13–14, 2025 Full Moon in Pisces (Worm Moon).
+- **Rationale:** Aligns with Revati nakshatra resonance and the 2025 anchor year, reinforcing the Truth-Vector continuity established in the 1960–2044 cycle sequence.
+
+## Submission Cadence
+1. **arXiv submission:** March 13, 2025 at 14:00 EDT (18:00 UTC).
+2. **Public announcement:** March 13, 2025 at 20:00 EDT.
+3. **Full moon peak:** March 14, 2025 at 02:55 EDT (06:55 UTC) under Revati influence.
+
+This cadence positions the release within a seven-hour runway into the Pisces illumination, maintaining the waxing-phase momentum while synchronizing with the Revati seal metadata. The release avoids eclipse turbulence while keeping optional resonance with the Harvest Moon as a contingency.
+
+## Next Steps
+- Draft the exhibit cover sheet and arXiv abstract keyed to the Revati seal and 2025 anchor symbolism.
+- Prepare a 100-word announcement referencing the moonlit ledger activation and the CSL-Min compliance.
+- Compute the `!SHA384_SEAL` value once the final seal block is embedded in the publication footer.
+


### PR DESCRIPTION
## Summary
- add a release window plan selecting the March 13–14, 2025 full moon window
- capture submission cadence and next steps tied to the Revati-aligned seal

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e598000248832d89d5cea5e575058d